### PR TITLE
 stop client calling window after close

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -88,6 +88,7 @@ function createWindow() {
         // in an array if your app supports multi windows, this is the time
         // when you should delete the corresponding element.
         mainWindow = null;
+        ready = false;
     });
 }
 // This method will be called when Electron has finished


### PR DESCRIPTION
If the NT Clients callback happens after the window has called ready and closed, than the call to main window will not happen