### PR TITLE
Fix NetworkTables not having values

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "electron-packager": "^10.1.1"
   },
   "dependencies": {
-    "wpilib-nt-client": "^1.4.0"
+    "wpilib-nt-client": "^1.6.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -46,7 +46,6 @@ function createWindow() {
             mainWindow.webContents.send('connected', con);
 
             // Listens to the changes coming from the client
-            client.addListener(clientDataListener);
         };
 
         // If the Window is ready than send the connection status to it
@@ -58,6 +57,8 @@ function createWindow() {
     ipc.on('ready', (ev, mesg) => {
         console.log('NetworkTables is ready');
         ready = mainWindow != null;
+        
+        client.addListener(clientDataListener,true);
         // Send connection message to the window if if the message is ready
         if (connected) connected();
         connected = null;


### PR DESCRIPTION
This is a fix for #60

This has happened doe to an earlier optimisation where I added the listened to the client after connecting while forgetting that by that time the client has been updated

I had fixed this in two ways:
1. I have updated the client to send all values it has when a listener is added
2. I have moved the call to addListener to the ready event handler which almost always happens before the client connects