### PR TITLE
Fix some connect modal issues

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -24,6 +24,8 @@ onkeydown = key => {
 buttonConnect.onclick = () => {
   document.body.classList.toggle('login', true);
   loginShown = true;
+  
+  setLogin();
 };
 
 /**
@@ -39,8 +41,6 @@ function onRobotConnection(connected) {
     // On connect hide the connect popup
     document.body.classList.toggle('login', false);
     loginShown = false;
-    
-    setLogin();
   } else if (loginShown) {
     setLogin();
   }

--- a/src/connection.js
+++ b/src/connection.js
@@ -21,6 +21,11 @@ onkeydown = key => {
   }
 };
 
+buttonConnect.onclick = () => {
+  document.body.classList.toggle('login', true);
+  loginShown = true;
+};
+
 /**
  * Function to be called when robot connects
  * @param {boolean} connected
@@ -29,15 +34,13 @@ function onRobotConnection(connected) {
   var state = connected ? 'Robot connected!' : 'Robot disconnected.';
   console.log(state);
   ui.robotState.textContent = state;
-
-  buttonConnect.onclick = () => {
-    document.body.classList.toggle('login', true);
-    loginShown = true;
-  };
+  
   if (connected) {
     // On connect hide the connect popup
     document.body.classList.toggle('login', false);
     loginShown = false;
+    
+    setLogin();
   } else if (loginShown) {
     setLogin();
   }


### PR DESCRIPTION
Here's what I did:
**The issue:** Open the software, hit Escape, then press the connect button. Nothing happens, because `onRobotConnection` hasn't been called yet.
**The solution:** I moved the `buttonConnect` event listener outside of `onRobotConnection`

**Another issue:** Let's say you connect FRC Dashboard to a robot. Then you decide to switch addresses for some reason (maybe you're running a local robot simulation), so you hit the connect button. The modal connect button says `Connecting...`, and you can't change the address.
**The awesome solution:** Call `setLogin()` every time `buttonConnect` is pressed, thus resetting the modal (but not the connection).

I discovered this while building this super cool Material theme 😄
![image](https://user-images.githubusercontent.com/34525547/65907512-7dfd6680-e392-11e9-91af-e62341f13e69.png)