### PR TITLE
Add FRC Web Components as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "http://frcdashboard.github.io",
   "dependencies": {
+    "@frc-web-components/frc-web-components": "^1.1.7",
     "wpilib-nt-client": "^1.7.1"
   },
   "devDependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -65,6 +65,11 @@
     <script src="networktables/networktables.js"></script>
     <script src="ui.js"></script>
     <script src="connection.js"></script>
+    <script src="../node_modules/@frc-web-components/frc-web-components/build/frc-web-components.min.js"></script>
+    <script>
+        webbitStore.addSourceProvider('NetworkTables');
+        webbitStore.setDefaultSourceProvider('NetworkTables');
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
This will allow users to add additional components to their dashboards without any additional javascript necessary. For example, if there's a **/SmartDashboard/drive/navx/yaw** key in NetworkTables they could add this HTML to their page: `<frc-gyro source-key="/SmartDashboard/drive/navx/yaw"></frc-gyro>` (and remove the existing gyro HTML as well) and you get this:

![Screen Shot 2020-05-10 at 2 30 05 PM](https://user-images.githubusercontent.com/6786620/81507423-5593fe00-92cb-11ea-83bf-446cef72112a.png)

Theming and styling for these components is currently limited. For example, the gyro component's dark text and svg shapes didn't show up well in the dark theme. For now only the light theme is completely supported, but I'm planning on adding theming options soon.

Most of the widgets in Shuffleboard have been added as components. Here are some other components you can add:

![Screen Shot 2020-05-10 at 2 53 28 PM](https://user-images.githubusercontent.com/6786620/81507846-11562d00-92ce-11ea-853b-05408fbcc942.png)
![Screen Shot 2020-05-10 at 2 53 15 PM](https://user-images.githubusercontent.com/6786620/81507847-11eec380-92ce-11ea-8ba3-4db138af5002.png)
![Screen Shot 2020-05-10 at 2 49 44 PM](https://user-images.githubusercontent.com/6786620/81507848-11eec380-92ce-11ea-8d1d-f159a4429158.png)
![Screen Shot 2020-05-10 at 2 49 29 PM](https://user-images.githubusercontent.com/6786620/81507849-12875a00-92ce-11ea-8d48-5662639ffb90.png)
![Screen Shot 2020-05-10 at 2 49 16 PM](https://user-images.githubusercontent.com/6786620/81507850-12875a00-92ce-11ea-84f0-a305c12cbc9d.png)

The github repo can be found here: https://github.com/frc-web-components/frc-web-components

Examples for every existing component can be found here: https://frc-web-components.github.io/examples/vanilla/index.html